### PR TITLE
Add mountain sounds for windswept hills

### DIFF
--- a/src/main/java/folk/sisby/euphonium/sounds/biome/Mountains.java
+++ b/src/main/java/folk/sisby/euphonium/sounds/biome/Mountains.java
@@ -18,7 +18,9 @@ import java.util.function.Predicate;
 
 public class Mountains implements ISoundType<BiomeSound> {
 	public static final Predicate<RegistryEntry<Biome>> VALID_BIOME = holder -> holder.isIn(BiomeTags.IS_MOUNTAIN)
-		|| holder.isIn(ConventionalBiomeTags.MOUNTAIN);
+		|| holder.isIn(ConventionalBiomeTags.MOUNTAIN)
+		|| holder.isIn(BiomeTags.IS_HILL)
+		|| holder.isIn(ConventionalBiomeTags.EXTREME_HILLS);
 	public static SoundEvent DAY_SOUND;
 	public static SoundEvent NIGHT_SOUND;
 


### PR DESCRIPTION
I have an old world with pre-1.18 generation, where old mountains ("extreme hills") have been converted to windswept hills in newer versions of the game. Euphonium doesn't play any sounds for those biomes, so I thought it would be fitting to include them in the mountain ambience.

Signed-off-by: starr4ever@TransEdenV4 <starflowerr777@gmail.com>
